### PR TITLE
[blobstore feature]: enables upload of images as parts of comments

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/BlobstoreUploadUrlServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/BlobstoreUploadUrlServlet.java
@@ -14,27 +14,28 @@
 
 package com.google.sps.servlets;
 
-import com.google.appengine.api.datastore.DatastoreService;
-import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import com.google.appengine.api.datastore.Key;
-import com.google.appengine.api.datastore.KeyFactory;
-import com.google.sps.servlets.Comment;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import com.google.sps.servlets.Comment;
 
-/** Servlet responsible for deleting tasks. */
-@WebServlet("/delete-data")
-public class DeleteCommentsServlet extends HttpServlet {
+/**
+ * When the fetch() function requests the /blobstore-upload-url URL, the content of the response is
+ * the URL that allows a user to upload a file to Blobstore.
+ */
+@WebServlet("/blobstore-upload-url")
+public class BlobstoreUploadUrlServlet extends HttpServlet {
 
   @Override
-  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    long id = Long.parseLong(request.getParameter("id"));
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+    String uploadUrl = blobstoreService.createUploadUrl("/data");
 
-    Key taskEntityKey = KeyFactory.createKey("Comment", id);
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    datastore.delete(taskEntityKey);
+    response.setContentType("text/html");
+    response.getWriter().println(uploadUrl);
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/Comment.java
@@ -20,10 +20,12 @@ public final class Comment {
     private final long id;
     private final String comment;
     private final long timestamp;
+    private final String imageUrl;
 
-    public Comment(long id, String comment, long timestamp) {
+    public Comment(long id, String comment, long timestamp, String imageUrl) {
         this.id = id;
         this.comment = comment;
         this.timestamp = timestamp;
+        this.imageUrl = imageUrl;
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -79,7 +79,7 @@ public class DataServlet extends HttpServlet {
     String name = getUserData(request, "user-name");
     String imageUrl = getUploadedFileUrl(request, "image");
 
-    if(comment == null || name == null) {
+    if(comment == null || name == null || imageUrl == null) {
       response.setContentType("text/html");
       response.getWriter().println("Please make sure all entries are filled.");
       return;
@@ -110,8 +110,7 @@ public class DataServlet extends HttpServlet {
   /** Returns a URL that points to the uploaded file, or null if the user did not upload a file. */
   private String getUploadedFileUrl(HttpServletRequest request, String formInputElementName) {
     BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
-    Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
-    List<BlobKey> blobKeys = blobs.get("image");
+    List<BlobKey> blobKeys = blobstoreService.getUploads(request).get("image");
 
     // User submitted form without selecting a file, so we can't get a URL. (dev server)
     if (blobKeys == null || blobKeys.isEmpty()) {
@@ -122,8 +121,7 @@ public class DataServlet extends HttpServlet {
     BlobKey blobKey = blobKeys.get(0);
 
     // User submitted form without selecting a file, so we can't get a URL. (live server)
-    BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
-    if (blobInfo.getSize() == 0) {
+    if (new BlobInfoFactory().loadBlobInfo(blobKey).getSize() == 0) {
       blobstoreService.delete(blobKey);
       return null;
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -89,7 +89,6 @@ public class DataServlet extends HttpServlet {
     Entity commentEntity = new Entity("Comment");
     commentEntity.setProperty("comment", userComment);
     commentEntity.setProperty("timestamp", timestamp);
-
     commentEntity.setProperty("imageUrl", imageUrl);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
@@ -110,7 +109,7 @@ public class DataServlet extends HttpServlet {
   /** Returns a URL that points to the uploaded file, or null if the user did not upload a file. */
   private String getUploadedFileUrl(HttpServletRequest request, String formInputElementName) {
     BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
-    List<BlobKey> blobKeys = blobstoreService.getUploads(request).get("image");
+    List<BlobKey> blobKeys = blobstoreService.getUploads(request).get(formInputElementName);
 
     // User submitted form without selecting a file, so we can't get a URL. (dev server)
     if (blobKeys == null || blobKeys.isEmpty()) {

--- a/portfolio/src/main/webapp/dinosaur.html
+++ b/portfolio/src/main/webapp/dinosaur.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400">
     <script src="script.js"></script>
   </head>
-  <body>
+  <body onload="fetchBlobstoreUrlAndShowForm()">
     <div id="content">
       <h1>[Project]Photos from the AMNH and the Met Museums</h1>
       <button onclick="toggleDetailsButton()">Click to Hide/Show Details</button>
@@ -26,18 +26,22 @@
       <div id="dinosaur-image-container"></div>
       <hr>
 
-      <form action="/data" method="POST">
+
+      <form id="my-form" class="hidden" method="POST" enctype="multipart/form-data">
         <h3>Comment Section</h3>
         <p>Your Name</p>
         <input type="text" name="user-name" minlength="1" required maxlength="150">
-        <br/><br/>
+        <br/>
         <p>Type Comment</p>
-        <input type="text" name="user-comment" minlength="1" required maxlength="300">
+        <textarea type="text" name="user-comment" minlength="1" required maxlength="300"></textarea>
+        <br/>
+        <p>Upload an image:</p>
+        <input type="file" name="image">
         <br/><br/>
-        <input type="submit">
-        <br/><br/>
-        <hr>
+        <button>Submit</button>
       </form>
+      <hr>
+      
       <br/>
       <h3> View Comments</h3>
       <p>Choose Number of Comments to See:</p>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -38,35 +38,51 @@ function toggleDetailsButton() {
 
 /** Gets the data from server sides. */
 function loadComments(value) {
-    fetch('/data?num=' + value)  
+    fetch('/data?num=' + value.toString())  
     .then(response => response.json()) 
     .then((data) => {
         createCommentElement(data, 'comments');
     });
 }
 
+/* Creates and returns an image element for displaying. */
+function addImage(src) {
+  const image = document.createElement('img');
+  image.setAttribute("src", src);
+  image.setAttribute("max-width", "304");
+  image.setAttribute("height", "auto");
+  image.setAttribute("alt", "User's Uploaded Image");
+  return image;
+}
+
 /** Creates an element for displaying comments. */
 function createCommentElement(data, attribute) {
-    const dataListElement = document.getElementById(attribute);
-    dataListElement.innerHTML = '';
+  const dataListElement = document.getElementById(attribute);
+  dataListElement.innerHTML = '';
     for(let i in data) {
-        const commentElement = document.createElement('li');
-        commentElement.className = 'comment';
+      const commentElement = document.createElement('dl');
+      const commentElementImage = document.createElement('dt');
+      const commentElementTitle = document.createElement('dt');
+      const commentElementDelete = document.createElement('dt');
+      commentElement.className = 'comment';
 
-        const titleElement = document.createElement('span');
-        titleElement.innerText = data[i].comment;
+      const deleteButtonElement = document.createElement('button');
+      deleteButtonElement.innerText = 'Delete';
+      deleteButtonElement.addEventListener('click', () => {
+        deleteComment(data[i]);
+        // Remove the task from the DOM.
+        commentElement.remove();
+      });
 
-        const deleteButtonElement = document.createElement('button');
-        deleteButtonElement.innerText = 'Delete';
-        deleteButtonElement.addEventListener('click', () => {
-            deleteComment(data[i]);
-            // Remove the task from the DOM.
-            commentElement.remove();
-        });
+      commentElementTitle.innerText = data[i].comment;
+      commentElementDelete.appendChild(deleteButtonElement);
+      commentElementImage.appendChild(addImage(data[i].imageUrl));
 
-        commentElement.appendChild(titleElement);
-        commentElement.appendChild(deleteButtonElement);
-        dataListElement.appendChild(commentElement);
+      commentElement.appendChild(commentElementImage)
+      .appendChild(commentElementTitle)
+      .appendChild(commentElementDelete);
+
+      dataListElement.appendChild(commentElement);
     }
 }
 
@@ -75,4 +91,17 @@ function deleteComment(comment) {
     const params = new URLSearchParams();
     params.append('id', comment.id);
     fetch('/delete-data', {method: 'POST', body: params});
+}
+
+/** Gets BlobStore url from the server. */
+function fetchBlobstoreUrlAndShowForm() {
+    fetch('/blobstore-upload-url')
+    .then((response) => {
+        return response.text();
+    })
+    .then((imageUploadUrl) => {
+        const messageForm = document.getElementById('my-form');
+        messageForm.action = imageUploadUrl;
+        messageForm.classList.remove('hidden');
+    });
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -11,14 +11,11 @@
   border-radius: 25px;
   border: thin solid #87CEFA;
   padding: 20px; 
-  width: 400px;  
+  max-width: 700px;  
   margin: 10px;
   display: flex;
+  flex-direction: column;
 
-}
-
-.comment span {
-  flex-grow: 1;
 }
 
 #content {
@@ -39,6 +36,10 @@
 .headshot {
   min-width: 80px;
   width: 25%;
+}
+
+.hidden {
+    display: none;
 }
 
 .image-thumbs img {


### PR DESCRIPTION
- used Blobstore API to process uploaded images and create image urls, that are stored in datastore as part of comments
- added an imageUrl variable to Comment.java
- created a new class BlobstoreUploadUrlServlet.java that allows a user to upload a file to blobstore
- added functions to script.js to allow the display of uploaded images
- NOTE: the deployed version does not work because of the API issue that Xi pointed out yesterday in the group-chat. However, the server version works for me, and this is a sample screenshot of the comment page with a user comment which includes an image upload

![image](https://user-images.githubusercontent.com/46787246/84156779-ee877780-aa37-11ea-86f1-26736161399f.png)
